### PR TITLE
[차소연] 회원가입, 로그인, 토큰 리프레시 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/CookSave/CookSaveback/Member/controller/MemberController.java
+++ b/src/main/java/CookSave/CookSaveback/Member/controller/MemberController.java
@@ -1,5 +1,7 @@
 package CookSave.CookSaveback.Member.controller;
 
+import CookSave.CookSaveback.Member.dto.LoginRequestDto;
+import CookSave.CookSaveback.Member.dto.LoginResponseDto;
 import CookSave.CookSaveback.Member.dto.SignUpRequestDto;
 import CookSave.CookSaveback.Member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -18,5 +20,12 @@ public class MemberController {
     @PostMapping("/signup")
     public ResponseEntity<String> signUp(@RequestBody SignUpRequestDto requestDto){
         return ResponseEntity.ok().body(memberService.signUp(requestDto.getCooksaveId(), requestDto.getPassword(), requestDto.getPasswordCheck()));
+    }
+    
+    // 로그인
+    // 성공적으로 로그인한 경우, 회원의 아이디, AccessToken 값, RefreshToken 값을 담은 DTO를 응답함
+    @PostMapping("/login")
+    public LoginResponseDto login(@RequestBody LoginRequestDto requestDto){
+        return memberService.login(requestDto.getCooksaveId(), requestDto.getPassword());
     }
 }

--- a/src/main/java/CookSave/CookSaveback/Member/controller/MemberController.java
+++ b/src/main/java/CookSave/CookSaveback/Member/controller/MemberController.java
@@ -2,6 +2,7 @@ package CookSave.CookSaveback.Member.controller;
 
 import CookSave.CookSaveback.Member.dto.LoginRequestDto;
 import CookSave.CookSaveback.Member.dto.LoginResponseDto;
+import CookSave.CookSaveback.Member.dto.RefreshRequestDto;
 import CookSave.CookSaveback.Member.dto.SignUpRequestDto;
 import CookSave.CookSaveback.Member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -27,5 +28,10 @@ public class MemberController {
     @PostMapping("/login")
     public LoginResponseDto login(@RequestBody LoginRequestDto requestDto){
         return memberService.login(requestDto.getCooksaveId(), requestDto.getPassword());
+    }
+
+    @PostMapping("/refresh")
+    public LoginResponseDto refresh(@RequestBody RefreshRequestDto refreshRequestDto){
+        return memberService.refresh(refreshRequestDto.getRefreshToken());
     }
 }

--- a/src/main/java/CookSave/CookSaveback/Member/controller/MemberController.java
+++ b/src/main/java/CookSave/CookSaveback/Member/controller/MemberController.java
@@ -1,0 +1,22 @@
+package CookSave.CookSaveback.Member.controller;
+
+import CookSave.CookSaveback.Member.dto.SignUpRequestDto;
+import CookSave.CookSaveback.Member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+    private final MemberService memberService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signUp(@RequestBody SignUpRequestDto requestDto){
+        return ResponseEntity.ok().body(memberService.signUp(requestDto.getCooksaveId(), requestDto.getPassword(), requestDto.getPasswordCheck()));
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/Member/controller/MemberController.java
+++ b/src/main/java/CookSave/CookSaveback/Member/controller/MemberController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
     private final MemberService memberService;
 
+    // 회원가입
     @PostMapping("/signup")
     public ResponseEntity<String> signUp(@RequestBody SignUpRequestDto requestDto){
         return ResponseEntity.ok().body(memberService.signUp(requestDto.getCooksaveId(), requestDto.getPassword(), requestDto.getPasswordCheck()));
@@ -30,6 +31,7 @@ public class MemberController {
         return memberService.login(requestDto.getCooksaveId(), requestDto.getPassword());
     }
 
+    // RefreshToken을 이용해 새 AccessToken 발급 요청
     @PostMapping("/refresh")
     public LoginResponseDto refresh(@RequestBody RefreshRequestDto refreshRequestDto){
         return memberService.refresh(refreshRequestDto.getRefreshToken());

--- a/src/main/java/CookSave/CookSaveback/Member/domain/RefreshToken.java
+++ b/src/main/java/CookSave/CookSaveback/Member/domain/RefreshToken.java
@@ -1,0 +1,23 @@
+package CookSave.CookSaveback.Member.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter @Setter
+@NoArgsConstructor
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long refreshTokenId;
+
+    // 토큰의 주인인 member의 고유 키
+    @Column(nullable = false)
+    private Long memberId;
+
+    // 토큰의 값
+    @Column(nullable = false)
+    private String value;
+}

--- a/src/main/java/CookSave/CookSaveback/Member/dto/LoginRequestDto.java
+++ b/src/main/java/CookSave/CookSaveback/Member/dto/LoginRequestDto.java
@@ -1,0 +1,11 @@
+package CookSave.CookSaveback.Member.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequestDto {
+    private String cooksaveId;
+    private String password;
+}

--- a/src/main/java/CookSave/CookSaveback/Member/dto/LoginResponseDto.java
+++ b/src/main/java/CookSave/CookSaveback/Member/dto/LoginResponseDto.java
@@ -1,0 +1,23 @@
+package CookSave.CookSaveback.Member.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginResponseDto {
+    private Long memberId;
+    private String cooksaveId;
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public LoginResponseDto(Long memberId, String cooksaveId, String accessToken, String refreshToken){
+        this.memberId = memberId;
+        this.cooksaveId = cooksaveId;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/Member/dto/RefreshRequestDto.java
+++ b/src/main/java/CookSave/CookSaveback/Member/dto/RefreshRequestDto.java
@@ -1,0 +1,10 @@
+package CookSave.CookSaveback.Member.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RefreshRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/CookSave/CookSaveback/Member/dto/SignUpRequestDto.java
+++ b/src/main/java/CookSave/CookSaveback/Member/dto/SignUpRequestDto.java
@@ -1,0 +1,13 @@
+package CookSave.CookSaveback.Member.dto;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignUpRequestDto {
+    private String cooksaveId;
+    private String password;
+    private String passwordCheck;  // 비밀번호 일치 확인을 위한 입력값
+}

--- a/src/main/java/CookSave/CookSaveback/Member/repository/MemberRepository.java
+++ b/src/main/java/CookSave/CookSaveback/Member/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package CookSave.CookSaveback.Member.repository;
+
+import CookSave.CookSaveback.Member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    // 아이디 중복검사를 위한 메서드
+    Boolean existsByCooksaveId(String cooksaveId);
+}

--- a/src/main/java/CookSave/CookSaveback/Member/repository/MemberRepository.java
+++ b/src/main/java/CookSave/CookSaveback/Member/repository/MemberRepository.java
@@ -4,8 +4,12 @@ import CookSave.CookSaveback.Member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     // 아이디 중복검사를 위한 메서드
     Boolean existsByCooksaveId(String cooksaveId);
+
+    Optional<Member> findByCooksaveId(String cooksaveId);
 }

--- a/src/main/java/CookSave/CookSaveback/Member/repository/RefreshTokenRepository.java
+++ b/src/main/java/CookSave/CookSaveback/Member/repository/RefreshTokenRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByValue(String value);
 }

--- a/src/main/java/CookSave/CookSaveback/Member/repository/RefreshTokenRepository.java
+++ b/src/main/java/CookSave/CookSaveback/Member/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package CookSave.CookSaveback.Member.repository;
+
+import CookSave.CookSaveback.Member.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/src/main/java/CookSave/CookSaveback/Member/service/MemberService.java
+++ b/src/main/java/CookSave/CookSaveback/Member/service/MemberService.java
@@ -1,0 +1,33 @@
+package CookSave.CookSaveback.Member.service;
+
+import CookSave.CookSaveback.Member.domain.Member;
+import CookSave.CookSaveback.Member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder encoder;
+
+    public String signUp(String cooksaveId, String password, String passwordCheck){
+        if(existsByCooksaveId(cooksaveId)) throw new RuntimeException(cooksaveId + "은 이미 존재하는 아이디입니다.");
+        // else if (!(Objects.equals(password, passwordCheck))) throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+
+        memberRepository.save(
+                Member.builder()
+                        .cooksaveId(cooksaveId)
+                        .password(encoder.encode(password))
+                        .build()
+        );
+        return "회원가입이 완료되었습니다.";
+        }
+
+    @Transactional(readOnly = true)
+    public boolean existsByCooksaveId(String cooksaveId){
+        return memberRepository.existsByCooksaveId(cooksaveId);
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/Member/service/MemberService.java
+++ b/src/main/java/CookSave/CookSaveback/Member/service/MemberService.java
@@ -5,6 +5,7 @@ import CookSave.CookSaveback.Member.domain.RefreshToken;
 import CookSave.CookSaveback.Member.dto.LoginResponseDto;
 import CookSave.CookSaveback.Member.repository.MemberRepository;
 import CookSave.CookSaveback.utils.JwtUtil;
+import io.jsonwebtoken.Claims;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -66,6 +67,33 @@ public class MemberService {
                 .cooksaveId(member.getCooksaveId())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .build();
+    }
+
+    // 재발급 구현은 다 했는데 아직 포스트맨 테스트 안 했음
+    // 코드 중간중간에 주석 아직 안 달았음
+    public LoginResponseDto refresh(String refreshTokenValue){
+        // 해당 RefreshToken이 유효한지 DB에서 탐색
+        RefreshToken refreshToken = refreshTokenService.findRefreshToken(refreshTokenValue);
+
+        // RefreshToken에 담긴 cooksaveId 값 가져오기
+        Claims claims = JwtUtil.parseRefreshToken(refreshToken.getValue(), refreshKey);
+        String cooksaveId = claims.get("cooksaveId").toString();
+        System.out.println("RefreshToken에 담긴 아이디 : " + cooksaveId);
+
+        // 가져온 cooksaveId에 해당하는 member가 존재하는지 확인
+        Member member = findMemberByCooksaveId(cooksaveId);
+
+        // 새 AccessToken 생성
+        String accessToken = JwtUtil.createAccessToken(member.getCooksaveId(), accessKey, AccessExpireTimeMs);
+
+        // 새 AccessToken과 기존 RefreshToken을 DTO에 담아 리턴
+        return LoginResponseDto
+                .builder()
+                .memberId(member.getMemberId())
+                .cooksaveId(member.getCooksaveId())
+                .accessToken(accessToken)
+                .refreshToken(refreshTokenValue)
                 .build();
     }
 

--- a/src/main/java/CookSave/CookSaveback/Member/service/MemberService.java
+++ b/src/main/java/CookSave/CookSaveback/Member/service/MemberService.java
@@ -1,8 +1,13 @@
 package CookSave.CookSaveback.Member.service;
 
 import CookSave.CookSaveback.Member.domain.Member;
+import CookSave.CookSaveback.Member.domain.RefreshToken;
+import CookSave.CookSaveback.Member.dto.LoginResponseDto;
 import CookSave.CookSaveback.Member.repository.MemberRepository;
+import CookSave.CookSaveback.utils.JwtUtil;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +17,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder encoder;
+    private final RefreshTokenService refreshTokenService;
+
+    @Value("${spring.jwt.secret-key}")
+    private String accessKey;
+
+    @Value("${spring.jwt.refresh-key}")
+    private String refreshKey;
+
+    // Access 토큰 만료 시간을 1시간으로 설정
+    private Long AccessExpireTimeMs = 1000 * 60 * 60L;
+
+    // Refresh 토큰 만료 시간을 7일로 설정
+    private Long RefreshExpireTimeMs = 7 * 24 * 1000 * 60 * 60L;
 
     public String signUp(String cooksaveId, String password, String passwordCheck){
         if(existsByCooksaveId(cooksaveId)) throw new RuntimeException(cooksaveId + "은 이미 존재하는 아이디입니다.");
@@ -24,10 +42,43 @@ public class MemberService {
                         .build()
         );
         return "회원가입이 완료되었습니다.";
-        }
+    }
 
+    // 로그인
+    public LoginResponseDto login(String cooksaveId, String password){
+        // 존재하지 않는 아이디로 로그인을 시도한 경우를 캐치
+        Member member = findMemberByCooksaveId(cooksaveId);
+
+        // 존재하는 아이디를 입력했지만 잘못된 비밀번호를 입력한 경우를 캐치
+        if(!encoder.matches(password, member.getPassword())) throw new RuntimeException("잘못된 비밀번호를 입력했습니다.");
+
+        // 로그인 성공 -> 토큰 생성
+        String accessToken = JwtUtil.createAccessToken(member.getCooksaveId(), accessKey, AccessExpireTimeMs);
+        String refreshToken = JwtUtil.createRefreshToken(member.getCooksaveId(), refreshKey, RefreshExpireTimeMs);
+
+        RefreshToken refreshTokenEntity = new RefreshToken();
+        refreshTokenEntity.setMemberId(member.getMemberId());
+        refreshTokenEntity.setValue(refreshToken);
+        refreshTokenService.addRefreshToken(refreshTokenEntity);
+
+        return LoginResponseDto.builder()
+                .memberId(member.getMemberId())
+                .cooksaveId(member.getCooksaveId())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    // 회원 가입 시 입력한 아이디를 가진 member 존재 여부 확인
     @Transactional(readOnly = true)
     public boolean existsByCooksaveId(String cooksaveId){
         return memberRepository.existsByCooksaveId(cooksaveId);
+    }
+
+    // 아이디로 member 찾기
+    @Transactional(readOnly = true)
+    public Member findMemberByCooksaveId(String cooksaveId){
+        return memberRepository.findByCooksaveId(cooksaveId)
+                .orElseThrow(() -> new EntityNotFoundException("아이디가 " + cooksaveId + "인 회원이 존재하지 않습니다."));
     }
 }

--- a/src/main/java/CookSave/CookSaveback/Member/service/RefreshTokenService.java
+++ b/src/main/java/CookSave/CookSaveback/Member/service/RefreshTokenService.java
@@ -1,0 +1,16 @@
+package CookSave.CookSaveback.Member.service;
+
+import CookSave.CookSaveback.Member.domain.RefreshToken;
+import CookSave.CookSaveback.Member.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public void addRefreshToken(RefreshToken refreshToken){
+        refreshTokenRepository.save(refreshToken);
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/Member/service/RefreshTokenService.java
+++ b/src/main/java/CookSave/CookSaveback/Member/service/RefreshTokenService.java
@@ -2,8 +2,10 @@ package CookSave.CookSaveback.Member.service;
 
 import CookSave.CookSaveback.Member.domain.RefreshToken;
 import CookSave.CookSaveback.Member.repository.RefreshTokenRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -12,5 +14,11 @@ public class RefreshTokenService {
 
     public void addRefreshToken(RefreshToken refreshToken){
         refreshTokenRepository.save(refreshToken);
+    }
+
+    @Transactional(readOnly = true)
+    public RefreshToken findRefreshToken(String refreshTokenValue){
+        return refreshTokenRepository.findByValue(refreshTokenValue)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 RefreshToken입니다."));
     }
 }

--- a/src/main/java/CookSave/CookSaveback/config/CORSConfig.java
+++ b/src/main/java/CookSave/CookSaveback/config/CORSConfig.java
@@ -1,0 +1,26 @@
+package CookSave.CookSaveback.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CORSConfig {
+    @Bean
+    public CorsFilter corsFilter(){
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin("https://www.cooksave.com");
+        config.addAllowedOrigin("http://localhost:3000");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+        config.setMaxAge(3600L);
+        config.addExposedHeader("Location");
+        config.addExposedHeader("Authorization");
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/config/EncoderConfig.java
+++ b/src/main/java/CookSave/CookSaveback/config/EncoderConfig.java
@@ -1,0 +1,13 @@
+package CookSave.CookSaveback.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class EncoderConfig {
+    @Bean
+    public BCryptPasswordEncoder encoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/config/JwtFilter.java
+++ b/src/main/java/CookSave/CookSaveback/config/JwtFilter.java
@@ -1,0 +1,60 @@
+package CookSave.CookSaveback.config;
+
+import CookSave.CookSaveback.utils.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+    private final String secretKey;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException{
+        // header에서 token 가져오기
+        final String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        log.info("authorization: {}", authorization);
+
+        // token이 null이 아닌지, Bearer 로 시작하는지 확인
+        if(authorization == null || !authorization.startsWith("Bearer ")){
+            log.error("올바르지 않은 authorization입니다.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // token에서 Bearer 떼어내서 token만 남기기
+        String token = authorization.split(" ")[1];  // authorization의 두 번째 단어
+
+        //token이 expire 되었는지 확인
+        if(JwtUtil.isExpired(token, secretKey)){
+            log.error("토큰이 만료되었습니다.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // token에서 cooksaveId 꺼내기
+        String cooksaveId = JwtUtil.getCooksaveId(token, secretKey);
+        log.info("cooksaveId:{}", cooksaveId);
+
+        // 권한 부여하기
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(cooksaveId, null, List.of(new SimpleGrantedAuthority("USER")));
+
+        // Detail 넣기
+        authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/config/SecurityConfig.java
+++ b/src/main/java/CookSave/CookSaveback/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package CookSave.CookSaveback.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    @Value("${spring.jwt.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain (HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity.httpBasic(HttpBasicConfigurer::disable)
+                .csrf(CsrfConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                .requestMatchers("/members/signup", "/members/login", "/members/refreshtoken").permitAll()  // 회원가입, 로그인은 무조건 허용
+                .requestMatchers(HttpMethod.POST, "/members/**").authenticated())  // 모든 POST 요청과, /members/로 시작하는 다른 URI의 모든 요청은 인증 요구
+                .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))  // JWT를 사용하므로 stateless
+                .addFilterBefore(new JwtFilter(secretKey), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/utils/JwtUtil.java
+++ b/src/main/java/CookSave/CookSaveback/utils/JwtUtil.java
@@ -1,0 +1,51 @@
+package CookSave.CookSaveback.utils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+import java.util.Date;
+
+public class JwtUtil {
+    // token이 expire 되었으면 true를 리턴하는 함수
+    public static boolean isExpired(String token, String secretKey){
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token)
+                .getBody().getExpiration().before(new Date());
+    }
+
+    // token에서 cooksaveId를 꺼내어 리턴하는 함수
+    public static String getCooksaveId(String token, String secretKey) {
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token)
+                .getBody().get("cooksavdId", String.class);
+    }
+
+    // token을 만드는 함수. createAccessToken과 createRefreshToken이 이 함수를 호출.
+    public static String createToken(String cooksaveId, String key, long expireTimeMs) {
+        Claims claims = Jwts.claims();  // 일종의 Map. 토큰 생성에 필요한 데이터를 담아두는 공간.
+        claims.put("cooksaveId", cooksaveId);  // 아이디를 저장
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))  // 발행 시각
+                .setExpiration(new Date(System.currentTimeMillis() + expireTimeMs))  // 만료 시각
+                .signWith(SignatureAlgorithm.HS256, key)  // HS256이라는 알고리즘과 주어진 key를 이용해 암호화
+                .compact();
+    }
+
+    // AccessToken을 만드는 함수
+    public static String createAccessToken(String cooksaveId, String key, long expireTimeMs) {
+        return createToken(cooksaveId, key, expireTimeMs);
+    }
+
+    // RefreshToken을 만드는 함수
+    public static String createRefreshToken (String cooksaveId, String key, long expireTimeMs) {
+        return createToken(cooksaveId, key, expireTimeMs);
+    }
+
+    public static Claims parseRefreshToken(String value, String key) {
+        return Jwts.parser()
+                .setSigningKey(key)
+                .parseClaimsJws(value)
+                .getBody();
+    }
+}


### PR DESCRIPTION
# 구현 기능
- 회원가입
- 로그인
- Refresh Token을 이용하여 Access Token 재발급

# 구현 상태
회원가입
<img width="862" alt="스크린샷 2024-01-28 133133 회원가입" src="https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/bf8c6d8b-d1d9-4525-9607-3864de9ebf3a">
<img width="218" alt="스크린샷 2024-01-28 133300 회원가입" src="https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/f19bd0d1-9c2d-49fb-b489-695147c4aea6">

로그인
<img width="642" alt="스크린샷 2024-01-28 154451 로그인" src="https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/c2308277-bc20-4846-83d1-83779ded6805">
<img width="337" alt="스크린샷 2024-01-28 154533 로그인" src="https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/fa10ce5c-53cc-415a-ab70-e6b020454718">

토큰 리프레시
<img width="637" alt="스크린샷 2024-02-05 162441 리프레시" src="https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/385bf5ed-8a8e-4e11-b763-6b640bf5401f">