### PR TITLE
[차소연] 재료 직접 등록, 전체 조회, 목록 수정, 삭제 기능 구현

### DIFF
--- a/src/main/java/CookSave/CookSaveback/CookSaveBackApplication.java
+++ b/src/main/java/CookSave/CookSaveback/CookSaveBackApplication.java
@@ -2,7 +2,9 @@ package CookSave.CookSaveback;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CookSaveBackApplication {
 

--- a/src/main/java/CookSave/CookSaveback/Icon/domain/Icon.java
+++ b/src/main/java/CookSave/CookSaveback/Icon/domain/Icon.java
@@ -12,7 +12,7 @@ public class Icon {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(nullable = false, updatable = false)
-    private Long iconId;
+    private Integer iconId;
 
     @Column(nullable = false)
     private String image;  // 아이콘 이미지 URL

--- a/src/main/java/CookSave/CookSaveback/Icon/repository/IconRepository.java
+++ b/src/main/java/CookSave/CookSaveback/Icon/repository/IconRepository.java
@@ -1,0 +1,9 @@
+package CookSave.CookSaveback.Icon.repository;
+
+import CookSave.CookSaveback.Icon.domain.Icon;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IconRepository extends JpaRepository<Icon, Integer> {
+}

--- a/src/main/java/CookSave/CookSaveback/Ingredient/controller/IngredientController.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/controller/IngredientController.java
@@ -33,6 +33,7 @@ public class IngredientController {
         return new ResponseEntity<>("재료가 등록되었습니다.", HttpStatus.CREATED);
     }
 
+    // 재료 목록에서 iconId, amount 수정
     @PatchMapping("/list")
     @ResponseStatus(value = HttpStatus.OK)
     public String updateIngredientList(@RequestBody List<UpdateRequestDto> updateRequestDtoList){

--- a/src/main/java/CookSave/CookSaveback/Ingredient/controller/IngredientController.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/controller/IngredientController.java
@@ -1,15 +1,13 @@
 package CookSave.CookSaveback.Ingredient.controller;
 
 import CookSave.CookSaveback.Ingredient.dto.IngredientRequestDto;
+import CookSave.CookSaveback.Ingredient.dto.IngredientResponseDto;
 import CookSave.CookSaveback.Ingredient.service.IngredientService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,6 +18,14 @@ import java.util.List;
 public class IngredientController {
     private final IngredientService ingredientService;
 
+    // 보유한 재료 목록 조회
+    @GetMapping
+    @ResponseStatus(value = HttpStatus.OK)
+    public List<IngredientResponseDto> getIngredientList(){
+        return ingredientService.getIngredientList();
+    }
+
+    // 재료 직접 입력
     @PostMapping("/typing")
     public ResponseEntity<String> createIngredientList(@RequestBody List<IngredientRequestDto> ingredientRequestDtoList){
         ingredientService.createIngredients(ingredientRequestDtoList);

--- a/src/main/java/CookSave/CookSaveback/Ingredient/controller/IngredientController.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/controller/IngredientController.java
@@ -40,4 +40,12 @@ public class IngredientController {
         ingredientService.updateIngredients(updateRequestDtoList);
         return "재료가 수정되었습니다.";
     }
+
+    // 재료 삭제
+    @DeleteMapping("/list/{ingredient_id}")
+    @ResponseStatus(value=HttpStatus.OK)
+    public String deleteIngredient(@PathVariable("ingredient_id") Long ingredientId){
+        ingredientService.deleteIngredient(ingredientId);
+        return "재료가 삭제되었습니다.";
+    }
 }

--- a/src/main/java/CookSave/CookSaveback/Ingredient/controller/IngredientController.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/controller/IngredientController.java
@@ -1,0 +1,28 @@
+package CookSave.CookSaveback.Ingredient.controller;
+
+import CookSave.CookSaveback.Ingredient.dto.IngredientRequestDto;
+import CookSave.CookSaveback.Ingredient.service.IngredientService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ingredients")
+public class IngredientController {
+    private final IngredientService ingredientService;
+
+    @PostMapping("/typing")
+    public ResponseEntity<String> createIngredientList(@RequestBody List<IngredientRequestDto> ingredientRequestDtoList){
+        ingredientService.createIngredients(ingredientRequestDtoList);
+        return new ResponseEntity<>("재료가 등록되었습니다.", HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/Ingredient/controller/IngredientController.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/controller/IngredientController.java
@@ -2,6 +2,7 @@ package CookSave.CookSaveback.Ingredient.controller;
 
 import CookSave.CookSaveback.Ingredient.dto.IngredientRequestDto;
 import CookSave.CookSaveback.Ingredient.dto.IngredientResponseDto;
+import CookSave.CookSaveback.Ingredient.dto.UpdateRequestDto;
 import CookSave.CookSaveback.Ingredient.service.IngredientService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +20,7 @@ public class IngredientController {
     private final IngredientService ingredientService;
 
     // 보유한 재료 목록 조회
-    @GetMapping
+    @GetMapping("/list")
     @ResponseStatus(value = HttpStatus.OK)
     public List<IngredientResponseDto> getIngredientList(){
         return ingredientService.getIngredientList();
@@ -30,5 +31,12 @@ public class IngredientController {
     public ResponseEntity<String> createIngredientList(@RequestBody List<IngredientRequestDto> ingredientRequestDtoList){
         ingredientService.createIngredients(ingredientRequestDtoList);
         return new ResponseEntity<>("재료가 등록되었습니다.", HttpStatus.CREATED);
+    }
+
+    @PatchMapping("/list")
+    @ResponseStatus(value = HttpStatus.OK)
+    public String updateIngredientList(@RequestBody List<UpdateRequestDto> updateRequestDtoList){
+        ingredientService.updateIngredients(updateRequestDtoList);
+        return "재료가 수정되었습니다.";
     }
 }

--- a/src/main/java/CookSave/CookSaveback/Ingredient/domain/Ingredient.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/domain/Ingredient.java
@@ -49,4 +49,9 @@ public class Ingredient extends BaseTimeEntity {
         this.price = price;
         this.amount = amount;
     }
+
+    public void updateIngredient(Icon icon, Float amount){
+        this.icon = icon;
+        this.amount = amount;
+    }
 }

--- a/src/main/java/CookSave/CookSaveback/Ingredient/domain/Ingredient.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/domain/Ingredient.java
@@ -24,7 +24,7 @@ public class Ingredient extends BaseTimeEntity {
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "tag_id", nullable = false)
+    @JoinColumn(name = "tag_id")  // 태그 지정 방식 정한 후 nullable=false 설정 여부 결정
     private Tag tag;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/CookSave/CookSaveback/Ingredient/dto/IngredientRequestDto.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/dto/IngredientRequestDto.java
@@ -1,0 +1,14 @@
+package CookSave.CookSaveback.Ingredient.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IngredientRequestDto {
+    private Integer iconId;
+    private String name;
+    private Integer price;
+    private Float amount;
+}

--- a/src/main/java/CookSave/CookSaveback/Ingredient/dto/IngredientResponseDto.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/dto/IngredientResponseDto.java
@@ -1,0 +1,27 @@
+package CookSave.CookSaveback.Ingredient.dto;
+
+import CookSave.CookSaveback.Ingredient.domain.Ingredient;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class IngredientResponseDto {
+    private Long ingredientId;
+    private Integer iconId;
+    private String name;
+    private Integer price;
+    private Float amount;
+    private LocalDateTime createdAt;
+
+    @Builder
+    public IngredientResponseDto(Ingredient ingredient){
+        this.ingredientId = ingredient.getIngredientId();
+        this.iconId = ingredient.getIcon().getIconId();
+        this.name = ingredient.getName();
+        this.price = ingredient.getPrice();
+        this.amount = ingredient.getAmount();
+        this.createdAt = ingredient.getCreatedAt();
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/Ingredient/dto/IngredientResponseDto.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/dto/IngredientResponseDto.java
@@ -3,7 +3,7 @@ package CookSave.CookSaveback.Ingredient.dto;
 import CookSave.CookSaveback.Ingredient.domain.Ingredient;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
@@ -13,7 +13,7 @@ public class IngredientResponseDto {
     private String name;
     private Integer price;
     private Float amount;
-    private LocalDateTime createdAt;
+    private LocalDate createdAt;
 
     @Builder
     public IngredientResponseDto(Ingredient ingredient){

--- a/src/main/java/CookSave/CookSaveback/Ingredient/dto/UpdateRequestDto.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/dto/UpdateRequestDto.java
@@ -1,0 +1,10 @@
+package CookSave.CookSaveback.Ingredient.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateRequestDto {
+    private Long ingredientId;
+    private Integer iconId;
+    private Float amount;
+}

--- a/src/main/java/CookSave/CookSaveback/Ingredient/repository/IngredientRepository.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/repository/IngredientRepository.java
@@ -7,9 +7,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     List<Ingredient> findAllByMember(Member member);
     Long countAllByMember(Member member);
+    Optional<Ingredient> findByIngredientIdAndMember(Long ingredientId, Member member);
 }

--- a/src/main/java/CookSave/CookSaveback/Ingredient/repository/IngredientRepository.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/repository/IngredientRepository.java
@@ -1,9 +1,14 @@
 package CookSave.CookSaveback.Ingredient.repository;
 
 import CookSave.CookSaveback.Ingredient.domain.Ingredient;
+
+import CookSave.CookSaveback.Member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+    List<Ingredient> findAllByMember(Member member);
 }

--- a/src/main/java/CookSave/CookSaveback/Ingredient/repository/IngredientRepository.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/repository/IngredientRepository.java
@@ -11,4 +11,5 @@ import java.util.List;
 @Repository
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     List<Ingredient> findAllByMember(Member member);
+    Long countAllByMember(Member member);
 }

--- a/src/main/java/CookSave/CookSaveback/Ingredient/repository/IngredientRepository.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/repository/IngredientRepository.java
@@ -1,0 +1,9 @@
+package CookSave.CookSaveback.Ingredient.repository;
+
+import CookSave.CookSaveback.Ingredient.domain.Ingredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+}

--- a/src/main/java/CookSave/CookSaveback/Ingredient/service/IngredientService.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/service/IngredientService.java
@@ -4,6 +4,7 @@ import CookSave.CookSaveback.Icon.domain.Icon;
 import CookSave.CookSaveback.Icon.repository.IconRepository;
 import CookSave.CookSaveback.Ingredient.domain.Ingredient;
 import CookSave.CookSaveback.Ingredient.dto.IngredientRequestDto;
+import CookSave.CookSaveback.Ingredient.dto.IngredientResponseDto;
 import CookSave.CookSaveback.Ingredient.repository.IngredientRepository;
 import CookSave.CookSaveback.Member.domain.Member;
 import CookSave.CookSaveback.Member.service.MemberService;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +22,19 @@ public class IngredientService {
     private final MemberService memberService;
     private final IconRepository iconRepository;
     private final IngredientRepository ingredientRepository;
+
+    public List<IngredientResponseDto> getIngredientList() {
+        List<Ingredient> ingredients = new ArrayList<>();
+        Member member = memberService.getLoginMember();
+        ingredients = ingredientRepository.findAllByMember(member);
+
+        List<IngredientResponseDto> ingredientList = new ArrayList<>();
+        for (Ingredient ingredient:ingredients){
+            IngredientResponseDto ingredientResponseDto = new IngredientResponseDto(ingredient);
+            ingredientList.add(ingredientResponseDto);
+        }
+        return ingredientList;
+    }
 
     public void createIngredients(List<IngredientRequestDto> ingredientDtos){
         List<Ingredient> ingredients = new ArrayList<>();

--- a/src/main/java/CookSave/CookSaveback/Ingredient/service/IngredientService.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/service/IngredientService.java
@@ -1,0 +1,44 @@
+package CookSave.CookSaveback.Ingredient.service;
+
+import CookSave.CookSaveback.Icon.domain.Icon;
+import CookSave.CookSaveback.Icon.repository.IconRepository;
+import CookSave.CookSaveback.Ingredient.domain.Ingredient;
+import CookSave.CookSaveback.Ingredient.dto.IngredientRequestDto;
+import CookSave.CookSaveback.Ingredient.repository.IngredientRepository;
+import CookSave.CookSaveback.Member.domain.Member;
+import CookSave.CookSaveback.Member.service.MemberService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class IngredientService {
+    private final MemberService memberService;
+    private final IconRepository iconRepository;
+    private final IngredientRepository ingredientRepository;
+
+    public void createIngredients(List<IngredientRequestDto> ingredientDtos){
+        List<Ingredient> ingredients = new ArrayList<>();
+
+        // 현재 로그인한 member 불러오기
+        Member member = memberService.getLoginMember();
+
+        for (IngredientRequestDto ingredientDto : ingredientDtos){
+            Icon icon = iconRepository.findById(ingredientDto.getIconId())
+                    .orElseThrow(() -> new EntityNotFoundException("iconId " + ingredientDto.getIconId() + "인 아이콘이 존재하지 않습니다."));
+            Ingredient ingredient = Ingredient.builder()
+                    .member(member)
+                    .tag(null)  // 태그 지정 방법 결정 후 수정 필요
+                    .icon(icon)
+                    .name(ingredientDto.getName())
+                    .price(ingredientDto.getPrice())
+                    .amount(ingredientDto.getAmount())
+                    .build();
+            ingredientRepository.save(ingredient);
+        }
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/Ingredient/service/IngredientService.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/service/IngredientService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +22,7 @@ public class IngredientService {
     private final IconRepository iconRepository;
     private final IngredientRepository ingredientRepository;
 
+    // 전체 재료 조회
     public List<IngredientResponseDto> getIngredientList() {
         List<Ingredient> ingredients = new ArrayList<>();
         Member member = memberService.getLoginMember();

--- a/src/main/java/CookSave/CookSaveback/Ingredient/service/IngredientService.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/service/IngredientService.java
@@ -5,6 +5,7 @@ import CookSave.CookSaveback.Icon.repository.IconRepository;
 import CookSave.CookSaveback.Ingredient.domain.Ingredient;
 import CookSave.CookSaveback.Ingredient.dto.IngredientRequestDto;
 import CookSave.CookSaveback.Ingredient.dto.IngredientResponseDto;
+import CookSave.CookSaveback.Ingredient.dto.UpdateRequestDto;
 import CookSave.CookSaveback.Ingredient.repository.IngredientRepository;
 import CookSave.CookSaveback.Member.domain.Member;
 import CookSave.CookSaveback.Member.service.MemberService;
@@ -54,6 +55,29 @@ public class IngredientService {
                     .amount(ingredientDto.getAmount())
                     .build();
             ingredientRepository.save(ingredient);
+        }
+    }
+
+    public void updateIngredients(List<UpdateRequestDto> updateRequestDtos){
+        List<Ingredient> ingredients = new ArrayList<>();
+
+        // 현재 로그인한 member 불러오기
+        Member member = memberService.getLoginMember();
+
+        // 업데이트 할 ingredient 개수 구하기
+        Long count = ingredientRepository.countAllByMember(member);
+        int intCount = (int)(long)count;
+
+        List<Ingredient> originalIngredients = ingredientRepository.findAllByMember(member);
+
+        for (int i = 0; i<intCount; i++){
+            // 업데이트 할 iconId, amount 값 불러오기
+            Integer iconId = updateRequestDtos.get(i).getIconId();
+            Icon icon = iconRepository.findById(iconId)
+                    .orElseThrow(() -> new EntityNotFoundException("iconId " + iconId + "인 아이콘이 존재하지 않습니다."));
+            Float amount = updateRequestDtos.get(i).getAmount();
+            originalIngredients.get(i).updateIngredient(icon, amount);
+            ingredientRepository.save(originalIngredients.get(i));
         }
     }
 }

--- a/src/main/java/CookSave/CookSaveback/Ingredient/service/IngredientService.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/service/IngredientService.java
@@ -81,4 +81,11 @@ public class IngredientService {
             ingredientRepository.save(originalIngredients.get(i));
         }
     }
+
+    public void deleteIngredient(Long ingredientId){
+        Member member = memberService.getLoginMember();
+        Ingredient ingredient = ingredientRepository.findByIngredientIdAndMember(ingredientId, member)
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 접근입니다."));
+        ingredientRepository.delete(ingredient);
+    }
 }

--- a/src/main/java/CookSave/CookSaveback/Ingredient/service/IngredientService.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/service/IngredientService.java
@@ -76,6 +76,7 @@ public class IngredientService {
             Icon icon = iconRepository.findById(iconId)
                     .orElseThrow(() -> new EntityNotFoundException("iconId " + iconId + "인 아이콘이 존재하지 않습니다."));
             Float amount = updateRequestDtos.get(i).getAmount();
+
             originalIngredients.get(i).updateIngredient(icon, amount);
             ingredientRepository.save(originalIngredients.get(i));
         }

--- a/src/main/java/CookSave/CookSaveback/Member/service/MemberService.java
+++ b/src/main/java/CookSave/CookSaveback/Member/service/MemberService.java
@@ -125,7 +125,6 @@ public class MemberService {
     public Member getLoginMember(){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String cooksaveId = authentication.getName();
-        System.out.println(cooksaveId + "getName에서 나온 거");
         return memberRepository.findByCooksaveId(cooksaveId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "인증된 회원 정보가 없습니다."));
     }

--- a/src/main/java/CookSave/CookSaveback/global/entity/BaseTimeEntity.java
+++ b/src/main/java/CookSave/CookSaveback/global/entity/BaseTimeEntity.java
@@ -2,6 +2,7 @@ package CookSave.CookSaveback.global.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -9,6 +10,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Getter
+@MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
     @CreatedDate

--- a/src/main/java/CookSave/CookSaveback/global/entity/BaseTimeEntity.java
+++ b/src/main/java/CookSave/CookSaveback/global/entity/BaseTimeEntity.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @MappedSuperclass
@@ -15,5 +15,5 @@ import java.time.LocalDateTime;
 public class BaseTimeEntity {
     @CreatedDate
     @Column(updatable = false)
-    private LocalDateTime createdAt;
+    private LocalDate createdAt;
 }


### PR DESCRIPTION
# 구현 기능
- 재료 리스트 직접 등록
- 전체 재료 목록 조회
- 재료 목록에서 아이콘, 수량 수정
- 재료 삭제

# 구현 상태
재료 직접 등록
![스크린샷 2024-02-18 213755 직접 등록](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/8f1cae9e-d0fd-4bd8-8938-e87f36d1cd69)
![스크린샷 2024-02-19 034747 직접 등록](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/3ca1930e-5b9d-4014-a2e0-b174d2191064)

전체 재료 조회
![스크린샷 2024-02-19 034404 전체 재료 조회](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/fbffcc9b-f255-4c25-bbf3-943e2d5e3307)

재료 수정
![스크린샷 2024-02-20 125136 재료 수정](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/1ba5d817-22ce-4568-b8ab-afd6a7621cbf)
![스크린샷 2024-02-20 125155 재료 수정](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/acc21df3-067a-488e-9d53-c0fda178fc9a)

재료 삭제
![스크린샷 2024-02-20 132004 재료 삭제](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/812867ec-e32b-4ec9-9816-d3b9af2af2ae)
![스크린샷 2024-02-20 132043  재료 삭제](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/576da792-e75d-48c7-b74f-0a16abf53468)