### PR TITLE
[차소연] 전체 레시피 조회, 레시피 상세 조회 기능 구현

### DIFF
--- a/src/main/java/CookSave/CookSaveback/Heart/repository/HeartRepository.java
+++ b/src/main/java/CookSave/CookSaveback/Heart/repository/HeartRepository.java
@@ -1,0 +1,12 @@
+package CookSave.CookSaveback.Heart.repository;
+
+import CookSave.CookSaveback.Heart.domain.Heart;
+import CookSave.CookSaveback.Member.domain.Member;
+import CookSave.CookSaveback.Recipe.domain.Recipe;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HeartRepository extends JpaRepository<Heart, Long> {
+    boolean existsByMemberAndRecipe(Member member, Recipe recipe);
+}

--- a/src/main/java/CookSave/CookSaveback/Recipe/controller/RecipeController.java
+++ b/src/main/java/CookSave/CookSaveback/Recipe/controller/RecipeController.java
@@ -2,6 +2,7 @@ package CookSave.CookSaveback.Recipe.controller;
 
 import CookSave.CookSaveback.Member.domain.Member;
 import CookSave.CookSaveback.Member.service.MemberService;
+import CookSave.CookSaveback.Recipe.dto.RecipeDetailResponseDto;
 import CookSave.CookSaveback.Recipe.dto.RecipeResponseDto;
 import CookSave.CookSaveback.Recipe.service.RecipeService;
 import lombok.RequiredArgsConstructor;
@@ -26,13 +27,11 @@ public class RecipeController {
         return recipeService.getRecipeList(member);
     }
 
-
-    /*
+    // 레시피 상세 조회
     @GetMapping("/{recipe_id}")
     @ResponseStatus(value = HttpStatus.OK)
     public RecipeDetailResponseDto getRecipeDetail(@PathVariable("recipe_id") Long recipeId){
         Member member = memberService.getLoginMember();
         return recipeService.getRecipeDetail(recipeId, member);
     }
-    */
 }

--- a/src/main/java/CookSave/CookSaveback/Recipe/controller/RecipeController.java
+++ b/src/main/java/CookSave/CookSaveback/Recipe/controller/RecipeController.java
@@ -1,0 +1,38 @@
+package CookSave.CookSaveback.Recipe.controller;
+
+import CookSave.CookSaveback.Member.domain.Member;
+import CookSave.CookSaveback.Member.service.MemberService;
+import CookSave.CookSaveback.Recipe.dto.RecipeResponseDto;
+import CookSave.CookSaveback.Recipe.service.RecipeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/recipes")
+public class RecipeController {
+    private final RecipeService recipeService;
+    private final MemberService memberService;
+
+
+    // 전체 레시피 목록 조회
+    @GetMapping
+    @ResponseStatus(value = HttpStatus.OK)
+    public List<RecipeResponseDto> getRecipeList(){
+        Member member = memberService.getLoginMember();
+        return recipeService.getRecipeList(member);
+    }
+
+
+    /*
+    @GetMapping("/{recipe_id}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public RecipeDetailResponseDto getRecipeDetail(@PathVariable("recipe_id") Long recipeId){
+        Member member = memberService.getLoginMember();
+        return recipeService.getRecipeDetail(recipeId, member);
+    }
+    */
+}

--- a/src/main/java/CookSave/CookSaveback/Recipe/dto/RecipeDetailResponseDto.java
+++ b/src/main/java/CookSave/CookSaveback/Recipe/dto/RecipeDetailResponseDto.java
@@ -1,0 +1,30 @@
+package CookSave.CookSaveback.Recipe.dto;
+
+import CookSave.CookSaveback.Ingredient.dto.IngredientResponseDto;
+import CookSave.CookSaveback.Recipe.domain.Recipe;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class RecipeDetailResponseDto {
+    private String image;
+    private String name;
+    private String mainIng;
+    private String content;
+    private List<IngredientResponseDto> ingredients;
+    private String video;
+
+    @Builder
+    public RecipeDetailResponseDto(Recipe recipe, List<IngredientResponseDto> ingredients){
+        this.image = recipe.getImage();
+        this.name = recipe.getName();
+        this.mainIng = recipe.getMainIng();
+        this.content = recipe.getContent();
+        this.ingredients = ingredients;
+        this.video = recipe.getVideo();
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/Recipe/dto/RecipeResponseDto.java
+++ b/src/main/java/CookSave/CookSaveback/Recipe/dto/RecipeResponseDto.java
@@ -1,0 +1,25 @@
+package CookSave.CookSaveback.Recipe.dto;
+
+import CookSave.CookSaveback.Recipe.domain.Recipe;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RecipeResponseDto {
+    private Long recipeId;
+    private String name;
+    private String image;
+    private String mainIng;
+    private boolean heart;
+
+    @Builder
+    public RecipeResponseDto(Recipe recipe, boolean heart){
+        this.recipeId = recipe.getRecipeId();
+        this.name = recipe.getName();
+        this.image = recipe.getImage();
+        this.mainIng = recipe.getMainIng();
+        this.heart = heart;
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/Recipe/repository/RecipeRepository.java
+++ b/src/main/java/CookSave/CookSaveback/Recipe/repository/RecipeRepository.java
@@ -1,0 +1,9 @@
+package CookSave.CookSaveback.Recipe.repository;
+
+import CookSave.CookSaveback.Recipe.domain.Recipe;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecipeRepository extends JpaRepository<Recipe, Long> {
+}

--- a/src/main/java/CookSave/CookSaveback/Recipe/service/RecipeService.java
+++ b/src/main/java/CookSave/CookSaveback/Recipe/service/RecipeService.java
@@ -1,0 +1,122 @@
+package CookSave.CookSaveback.Recipe.service;
+
+import CookSave.CookSaveback.Heart.repository.HeartRepository;
+import CookSave.CookSaveback.Ingredient.domain.Ingredient;
+import CookSave.CookSaveback.Ingredient.dto.IngredientResponseDto;
+import CookSave.CookSaveback.Ingredient.repository.IngredientRepository;
+import CookSave.CookSaveback.Member.domain.Member;
+import CookSave.CookSaveback.Member.service.MemberService;
+import CookSave.CookSaveback.Recipe.domain.Recipe;
+import CookSave.CookSaveback.Recipe.dto.RecipeDetailResponseDto;
+import CookSave.CookSaveback.Recipe.dto.RecipeResponseDto;
+import CookSave.CookSaveback.Recipe.repository.RecipeRepository;
+import CookSave.CookSaveback.RecipeTag.repository.RecipeTagRepository;
+import CookSave.CookSaveback.Tag.domain.Tag;
+import CookSave.CookSaveback.Tag.repository.TagRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RecipeService {
+    private final RecipeRepository recipeRepository;
+    private final IngredientRepository ingredientRepository;
+    private final RecipeTagRepository recipeTagRepository;
+    private final HeartRepository heartRepository;
+    private final TagRepository tagRepository;
+
+    // 전체 레시피 조회
+    public List<RecipeResponseDto> getRecipeList(Member member) {
+        List<RecipeResponseDto> recipeList = new ArrayList<>();
+
+        List<Recipe> recipes = new ArrayList<>();
+        recipes = recipeRepository.findAll();
+        int recipeCount = recipes.size();
+
+        List<Ingredient> ingredients = new ArrayList<>();
+        ingredients = ingredientRepository.findAllByMember(member);
+
+        List<Integer> tags = new ArrayList<>();
+        for (Ingredient ingredient : ingredients) {
+            tags.add(ingredient.getTag().getTagId());
+            tags = tags.stream().distinct().collect(Collectors.toList());
+        }
+        int tagCount = tags.size();
+
+        List<Integer> recipeTagCount = new ArrayList<>();
+
+        for (int i = 0; i < recipeCount; i++) {
+            recipeTagCount.add(0);
+        }
+
+        for (int i = 0; i < recipeCount; i++) {
+            for (Integer tagId : tags) {
+                Tag tag = tagRepository.findById(tagId)
+                        .orElseThrow(() -> new EntityNotFoundException("해당되는 태그가 존재하지 않습니다."));
+                if (recipeTagRepository.existsByRecipeAndTag(recipes.get(i), tag)) {
+                    Integer currentCount = recipeTagCount.get(i);
+                    Integer newCount = currentCount == null ? 0 : currentCount + 1;
+                    recipeTagCount.set(i, newCount);
+                }
+            }
+        }
+
+        List<RecipeTagSort> sortedRecipeList = new ArrayList<>();
+        for (int i = 0; i < recipeCount; i++) {
+            sortedRecipeList.add(new RecipeTagSort(recipes.get(i), recipeTagCount.get(i)));
+        }
+
+        Comparator<RecipeTagSort> recipeComparator = Comparator.comparingInt(RecipeTagSort::getTagCount).reversed();
+        sortedRecipeList.sort(recipeComparator);
+
+        for (RecipeTagSort recipeTagSort : sortedRecipeList){
+            Recipe recipe = recipeTagSort.getRecipe();
+            boolean heart = heartRepository.existsByMemberAndRecipe(member, recipe);
+            RecipeResponseDto recipeResponseDto = new RecipeResponseDto(recipe, heart);
+            recipeList.add(recipeResponseDto);
+        }
+        return recipeList;
+    }
+
+    static class RecipeTagSort {
+        private Recipe recipe;
+        private int tagCount;
+
+        public RecipeTagSort(Recipe recipe, int tagCount) {
+            this.recipe = recipe;
+            this.tagCount = tagCount;
+        }
+
+        public Recipe getRecipe() {
+            return recipe;
+        }
+
+        public int getTagCount() {
+            return tagCount;
+        }
+    }
+
+    /*
+    public RecipeDetailResponseDto getRecipeDetail(Long recipeId, Member member){
+
+         Recipe recipe = recipeRepository.findById(recipeId)
+                .orElseThrow(() -> new EntityNotFoundException("recipeId가 " + recipeId + "인 레시피가 존재하지 않습니다."));
+
+        List<Ingredient> memberIngredients = ingredientRepository.findAllByMember(member);
+
+        for (Ingredient ingredient : memberIngredients){
+            Tag tag = tagRepository.findById(ingredient.getTag().getTagId())
+                    .orElseThrow(() -> new EntityNotFoundException("tagId" + ingredient.getTag().getTagId() + "인 태그가 존재하지 않습니다."));
+            if (recipeTagRepository.existsByRecipeAndTag(recipe, tag)){
+
+            }
+        }
+
+        RecipeDetailResponseDto detailResponseDto = new RecipeDetailResponseDto(recipe, ingredients);
+    }
+     */
+}

--- a/src/main/java/CookSave/CookSaveback/Recipe/service/RecipeService.java
+++ b/src/main/java/CookSave/CookSaveback/Recipe/service/RecipeService.java
@@ -100,7 +100,7 @@ public class RecipeService {
         }
     }
 
-    /*
+    // 레시피 상세 조회
     public RecipeDetailResponseDto getRecipeDetail(Long recipeId, Member member){
 
          Recipe recipe = recipeRepository.findById(recipeId)
@@ -108,15 +108,23 @@ public class RecipeService {
 
         List<Ingredient> memberIngredients = ingredientRepository.findAllByMember(member);
 
+        List<Ingredient> recipeIngredients = new ArrayList<>();
+
         for (Ingredient ingredient : memberIngredients){
             Tag tag = tagRepository.findById(ingredient.getTag().getTagId())
                     .orElseThrow(() -> new EntityNotFoundException("tagId" + ingredient.getTag().getTagId() + "인 태그가 존재하지 않습니다."));
             if (recipeTagRepository.existsByRecipeAndTag(recipe, tag)){
-
+                recipeIngredients.add(ingredient);
             }
         }
 
-        RecipeDetailResponseDto detailResponseDto = new RecipeDetailResponseDto(recipe, ingredients);
+        List<IngredientResponseDto> ingredients = new ArrayList<>();
+
+        for (Ingredient ingredient : recipeIngredients){
+            IngredientResponseDto ingredientResponseDto = new IngredientResponseDto(ingredient);
+            ingredients.add(ingredientResponseDto);
+        }
+
+        return new RecipeDetailResponseDto(recipe, ingredients);
     }
-     */
 }

--- a/src/main/java/CookSave/CookSaveback/RecipeTag/repository/RecipeTagRepository.java
+++ b/src/main/java/CookSave/CookSaveback/RecipeTag/repository/RecipeTagRepository.java
@@ -1,0 +1,12 @@
+package CookSave.CookSaveback.RecipeTag.repository;
+
+import CookSave.CookSaveback.Recipe.domain.Recipe;
+import CookSave.CookSaveback.RecipeTag.domain.RecipeTag;
+import CookSave.CookSaveback.Tag.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecipeTagRepository extends JpaRepository<RecipeTag, Long> {
+    boolean existsByRecipeAndTag(Recipe recipe, Tag tag);
+}

--- a/src/main/java/CookSave/CookSaveback/Tag/repository/TagRepository.java
+++ b/src/main/java/CookSave/CookSaveback/Tag/repository/TagRepository.java
@@ -1,0 +1,9 @@
+package CookSave.CookSaveback.Tag.repository;
+
+import CookSave.CookSaveback.Tag.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Integer>{
+}


### PR DESCRIPTION
# 구현 기능
- 전체 레시피 조회
- 레시피 상세 조회

# 구현 상태
전체 레시피 조회
![스크린샷 2024-02-20 213858 레시피 전체 조회](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/2705cd08-9c64-45b8-971f-ce4c5b2dffda)
![스크린샷 2024-02-20 210050 전체 레시피 조회](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/70d7c13c-e833-4c5f-b956-c49c7846a133)
![스크린샷 2024-02-20 210020 전체 레시피 조회](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/547ce52b-2c30-4f6f-8adc-1794bcae5051)

레시피 상세 조회
![스크린샷 2024-02-20 212701 레시피 상세 조회](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/61a4f971-c7b7-4544-867b-d603710b336f)