### PR TITLE
[차소연] 레시피 찜 등록, 취소, 찜한 레시피 목록 조회 기능 구현

### DIFF
--- a/src/main/java/CookSave/CookSaveback/Heart/controller/HeartController.java
+++ b/src/main/java/CookSave/CookSaveback/Heart/controller/HeartController.java
@@ -1,5 +1,6 @@
 package CookSave.CookSaveback.Heart.controller;
 
+import CookSave.CookSaveback.Heart.dto.HeartRecipeDto;
 import CookSave.CookSaveback.Heart.service.HeartService;
 import CookSave.CookSaveback.Member.domain.Member;
 import CookSave.CookSaveback.Member.service.MemberService;
@@ -7,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,5 +32,13 @@ public class HeartController {
         Member member = memberService.getLoginMember();
         String response = heartService.cancelRecipeHeart(member, recipeId);
         return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    // 찜한 레시피 목록 조회
+    @GetMapping("/saved")
+    @ResponseStatus(value = HttpStatus.OK)
+    public List<HeartRecipeDto> getHeartRecipeList(){
+        Member member = memberService.getLoginMember();
+        return heartService.getHeartRecipeList(member);
     }
 }

--- a/src/main/java/CookSave/CookSaveback/Heart/controller/HeartController.java
+++ b/src/main/java/CookSave/CookSaveback/Heart/controller/HeartController.java
@@ -6,10 +6,7 @@ import CookSave.CookSaveback.Member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +21,13 @@ public class HeartController {
         Member member = memberService.getLoginMember();
         String response = heartService.heartRecipe(member, recipeId);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    // 레시피 찜 취소
+    @DeleteMapping("/{recipe_id}/hearts")
+    public ResponseEntity<String> cancelRecipeHeart(@PathVariable("recipe_id") Long recipeId){
+        Member member = memberService.getLoginMember();
+        String response = heartService.cancelRecipeHeart(member, recipeId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/CookSave/CookSaveback/Heart/controller/HeartController.java
+++ b/src/main/java/CookSave/CookSaveback/Heart/controller/HeartController.java
@@ -1,0 +1,28 @@
+package CookSave.CookSaveback.Heart.controller;
+
+import CookSave.CookSaveback.Heart.service.HeartService;
+import CookSave.CookSaveback.Member.domain.Member;
+import CookSave.CookSaveback.Member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/recipes")
+public class HeartController {
+    private final MemberService memberService;
+    private final HeartService heartService;
+
+    // 레시피 찜 등록
+    @PostMapping("/{recipe_id}/hearts")
+    public ResponseEntity<String> heartRecipe(@PathVariable("recipe_id") Long recipeId){
+        Member member = memberService.getLoginMember();
+        String response = heartService.heartRecipe(member, recipeId);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/Heart/dto/HeartRecipeDto.java
+++ b/src/main/java/CookSave/CookSaveback/Heart/dto/HeartRecipeDto.java
@@ -1,0 +1,29 @@
+package CookSave.CookSaveback.Heart.dto;
+
+import CookSave.CookSaveback.Heart.domain.Heart;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class HeartRecipeDto {
+    private Long heartId;
+    private Long memberId;
+    private Long recipeId;
+    private String name;
+    private String image;
+    private List<String> tags;
+
+    @Builder
+    public HeartRecipeDto(Heart heart, List<String> tags){
+        this.heartId = heart.getHeartId();
+        this.memberId = heart.getMember().getMemberId();
+        this.recipeId = heart.getRecipe().getRecipeId();
+        this.name = heart.getRecipe().getName();
+        this.image = heart.getRecipe().getImage();
+        this.tags = tags;
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/Heart/repository/HeartRepository.java
+++ b/src/main/java/CookSave/CookSaveback/Heart/repository/HeartRepository.java
@@ -6,10 +6,12 @@ import CookSave.CookSaveback.Recipe.domain.Recipe;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface HeartRepository extends JpaRepository<Heart, Long> {
     boolean existsByMemberAndRecipe(Member member, Recipe recipe);
     Optional<Heart> findByMemberAndRecipe(Member member, Recipe recipe);
+    List<Heart> findAllByMember(Member member);
 }

--- a/src/main/java/CookSave/CookSaveback/Heart/repository/HeartRepository.java
+++ b/src/main/java/CookSave/CookSaveback/Heart/repository/HeartRepository.java
@@ -6,7 +6,10 @@ import CookSave.CookSaveback.Recipe.domain.Recipe;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface HeartRepository extends JpaRepository<Heart, Long> {
     boolean existsByMemberAndRecipe(Member member, Recipe recipe);
+    Optional<Heart> findByMemberAndRecipe(Member member, Recipe recipe);
 }

--- a/src/main/java/CookSave/CookSaveback/Heart/service/HeartService.java
+++ b/src/main/java/CookSave/CookSaveback/Heart/service/HeartService.java
@@ -1,20 +1,31 @@
 package CookSave.CookSaveback.Heart.service;
 
 import CookSave.CookSaveback.Heart.domain.Heart;
+import CookSave.CookSaveback.Heart.dto.HeartRecipeDto;
 import CookSave.CookSaveback.Heart.repository.HeartRepository;
+import CookSave.CookSaveback.Ingredient.domain.Ingredient;
+import CookSave.CookSaveback.Ingredient.repository.IngredientRepository;
 import CookSave.CookSaveback.Member.domain.Member;
 import CookSave.CookSaveback.Recipe.domain.Recipe;
 import CookSave.CookSaveback.Recipe.repository.RecipeRepository;
+import CookSave.CookSaveback.RecipeTag.domain.RecipeTag;
+import CookSave.CookSaveback.RecipeTag.repository.RecipeTagRepository;
+import CookSave.CookSaveback.Tag.domain.Tag;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class HeartService {
     private final HeartRepository heartRepository;
     private final RecipeRepository recipeRepository;
+    private final IngredientRepository ingredientRepository;
+    private final RecipeTagRepository recipeTagRepository;
 
     @Transactional
     public String heartRecipe(Member member, Long recipeId){
@@ -38,5 +49,36 @@ public class HeartService {
                 .orElseThrow(() -> new EntityNotFoundException("해당 레시피는 찜 목록에 존재하지 않습니다."));
         heartRepository.delete(heart);
         return "recipeId가 " + recipeId + "인 레시피가 찜 목록에서 제거되었습니다.";
+    }
+
+    public List<HeartRecipeDto> getHeartRecipeList(Member member){
+        List<HeartRecipeDto> heartRecipeDtoList = new ArrayList<>();
+
+        List<Heart> heartList = heartRepository.findAllByMember(member);
+        List<Ingredient> ingredientList = ingredientRepository.findAllByMember(member);
+        List<Tag> ingredientTagList = new ArrayList<>();
+
+        for(Ingredient ingredient : ingredientList){
+            ingredientTagList.add(ingredient.getTag());
+        }
+
+        for(Heart heart : heartList){
+            List<String> tags = new ArrayList<>();
+            Recipe recipe = heart.getRecipe();
+            List<RecipeTag> recipeTagList = recipeTagRepository.findAllByRecipe(recipe);
+
+            List<Tag> tagList = new ArrayList<>();
+            for(RecipeTag recipeTag : recipeTagList){
+                tagList.add(recipeTag.getTag());
+            }
+
+            for(Tag tag : tagList){
+                if(ingredientTagList.contains(tag)){
+                    tags.add(tag.getName());
+                }
+            }
+            heartRecipeDtoList.add(new HeartRecipeDto(heart, tags));
+        }
+        return heartRecipeDtoList;
     }
 }

--- a/src/main/java/CookSave/CookSaveback/Heart/service/HeartService.java
+++ b/src/main/java/CookSave/CookSaveback/Heart/service/HeartService.java
@@ -30,5 +30,13 @@ public class HeartService {
         }
     }
 
-
+    @Transactional
+    public String cancelRecipeHeart(Member member, Long recipeId){
+        Recipe recipe = recipeRepository.findById(recipeId)
+                .orElseThrow(() -> new EntityNotFoundException("recipeId가 " + recipeId + "인 레시피가 없습니다."));
+        Heart heart = heartRepository.findByMemberAndRecipe(member, recipe)
+                .orElseThrow(() -> new EntityNotFoundException("해당 레시피는 찜 목록에 존재하지 않습니다."));
+        heartRepository.delete(heart);
+        return "recipeId가 " + recipeId + "인 레시피가 찜 목록에서 제거되었습니다.";
+    }
 }

--- a/src/main/java/CookSave/CookSaveback/Heart/service/HeartService.java
+++ b/src/main/java/CookSave/CookSaveback/Heart/service/HeartService.java
@@ -1,0 +1,34 @@
+package CookSave.CookSaveback.Heart.service;
+
+import CookSave.CookSaveback.Heart.domain.Heart;
+import CookSave.CookSaveback.Heart.repository.HeartRepository;
+import CookSave.CookSaveback.Member.domain.Member;
+import CookSave.CookSaveback.Recipe.domain.Recipe;
+import CookSave.CookSaveback.Recipe.repository.RecipeRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class HeartService {
+    private final HeartRepository heartRepository;
+    private final RecipeRepository recipeRepository;
+
+    @Transactional
+    public String heartRecipe(Member member, Long recipeId){
+        Recipe recipe = recipeRepository.findById(recipeId)
+                .orElseThrow(() -> new EntityNotFoundException("recipeId가 " + recipeId + "인 레시피가 없습니다."));
+        if(heartRepository.existsByMemberAndRecipe(member, recipe)){
+            throw new RuntimeException("이미 저장 목록에 추가된 레시피입니다.");
+        }
+        else{
+            Heart heart = new Heart(member, recipe);
+            heartRepository.save(heart);
+            return "recipeId가 " + recipeId + "인 레시피가 찜 목록에 추가되었습니다.";
+        }
+    }
+
+
+}

--- a/src/main/java/CookSave/CookSaveback/Ingredient/repository/IngredientRepository.java
+++ b/src/main/java/CookSave/CookSaveback/Ingredient/repository/IngredientRepository.java
@@ -3,6 +3,7 @@ package CookSave.CookSaveback.Ingredient.repository;
 import CookSave.CookSaveback.Ingredient.domain.Ingredient;
 
 import CookSave.CookSaveback.Member.domain.Member;
+import CookSave.CookSaveback.Tag.domain.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,4 +15,5 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     List<Ingredient> findAllByMember(Member member);
     Long countAllByMember(Member member);
     Optional<Ingredient> findByIngredientIdAndMember(Long ingredientId, Member member);
+    boolean existsByMemberAndTag(Member member, Tag tag);
 }

--- a/src/main/java/CookSave/CookSaveback/RecipeTag/repository/RecipeTagRepository.java
+++ b/src/main/java/CookSave/CookSaveback/RecipeTag/repository/RecipeTagRepository.java
@@ -6,7 +6,10 @@ import CookSave.CookSaveback.Tag.domain.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface RecipeTagRepository extends JpaRepository<RecipeTag, Long> {
     boolean existsByRecipeAndTag(Recipe recipe, Tag tag);
+    List<RecipeTag> findAllByRecipe(Recipe recipe);
 }


### PR DESCRIPTION
# 구현 기능
- 레시피 찜 등록
- 레시피 찜 취소
- 찜한 레시피 목록 조회
  - 각 레시피에 필요한 재료 중 사용자가 가지고 있는 재료 리스트도 조회되도록 구현

# 구현 상태
레시피 찜 등록
![스크린샷 2024-02-21 024807 레시피 찜](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/05601dcc-6803-447a-968e-2b080eca635f)
![스크린샷 2024-02-21 024836 레시피 찜](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/23946796-ee61-4f44-9498-e22051db4032)

레시피 찜 취소
![스크린샷 2024-02-21 030113 레시피 찜 취소](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/5b6864df-5d3f-4d08-9d87-62e178d9ce47)

찜한 레시피 목록 조회
![스크린샷 2024-02-21 193732 찜한 레시피 목록 조회](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/dfecc39d-ae96-4cdf-a626-5cd905010f20)