### PR TITLE
[차소연] 예산 설정, 요리 내역 저장 기능 구현

### DIFF
--- a/src/main/java/CookSave/CookSaveback/History/controller/HistoryController.java
+++ b/src/main/java/CookSave/CookSaveback/History/controller/HistoryController.java
@@ -1,0 +1,27 @@
+package CookSave.CookSaveback.History.controller;
+
+import CookSave.CookSaveback.History.dto.BudgetRequestDto;
+import CookSave.CookSaveback.History.service.HistoryService;
+import CookSave.CookSaveback.Member.domain.Member;
+import CookSave.CookSaveback.Member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class HistoryController {
+    private final MemberService memberService;
+    private final HistoryService historyService;
+
+    // 예산 설정
+    @PatchMapping("members/budget")
+    public ResponseEntity<String> updateBudget(@RequestBody BudgetRequestDto budgetRequestDto){
+        Member member = memberService.getLoginMember();
+        historyService.updateBudget(member, budgetRequestDto);
+        return new ResponseEntity<>("예산이 설정되었습니다.", HttpStatus.OK);
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/History/controller/HistoryController.java
+++ b/src/main/java/CookSave/CookSaveback/History/controller/HistoryController.java
@@ -1,15 +1,14 @@
 package CookSave.CookSaveback.History.controller;
 
 import CookSave.CookSaveback.History.dto.BudgetRequestDto;
+import CookSave.CookSaveback.History.dto.RecipeHistoryReqDto;
 import CookSave.CookSaveback.History.service.HistoryService;
 import CookSave.CookSaveback.Member.domain.Member;
 import CookSave.CookSaveback.Member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,5 +22,13 @@ public class HistoryController {
         Member member = memberService.getLoginMember();
         historyService.updateBudget(member, budgetRequestDto);
         return new ResponseEntity<>("예산이 설정되었습니다.", HttpStatus.OK);
+    }
+
+    // 레시피 요리 내역 저장
+    @PostMapping("/recipes/{recipe_id}/ingredients")
+    public ResponseEntity<String> createRecipeHistory(@PathVariable("recipe_id") Long recipeId, @RequestBody RecipeHistoryReqDto recipeHistoryReqDto){
+        Member member = memberService.getLoginMember();
+        historyService.createRecipeHistory(member, recipeId, recipeHistoryReqDto);
+        return new ResponseEntity<>("요리 내역이 저장되었습니다.", HttpStatus.CREATED);
     }
 }

--- a/src/main/java/CookSave/CookSaveback/History/controller/HistoryController.java
+++ b/src/main/java/CookSave/CookSaveback/History/controller/HistoryController.java
@@ -1,6 +1,7 @@
 package CookSave.CookSaveback.History.controller;
 
 import CookSave.CookSaveback.History.dto.BudgetRequestDto;
+import CookSave.CookSaveback.History.dto.InputHistoryReqDto;
 import CookSave.CookSaveback.History.dto.RecipeHistoryReqDto;
 import CookSave.CookSaveback.History.service.HistoryService;
 import CookSave.CookSaveback.Member.domain.Member;
@@ -29,6 +30,14 @@ public class HistoryController {
     public ResponseEntity<String> createRecipeHistory(@PathVariable("recipe_id") Long recipeId, @RequestBody RecipeHistoryReqDto recipeHistoryReqDto){
         Member member = memberService.getLoginMember();
         historyService.createRecipeHistory(member, recipeId, recipeHistoryReqDto);
+        return new ResponseEntity<>("요리 내역이 저장되었습니다.", HttpStatus.CREATED);
+    }
+
+    // 사용자 입력 레시피 요리 내역 저장
+    @PostMapping("/recipes/input/ingredients")
+    public ResponseEntity<String> createInputHistory(@RequestBody InputHistoryReqDto inputHistoryReqDto){
+        Member member = memberService.getLoginMember();
+        historyService.createInputHistory(member, inputHistoryReqDto);
         return new ResponseEntity<>("요리 내역이 저장되었습니다.", HttpStatus.CREATED);
     }
 }

--- a/src/main/java/CookSave/CookSaveback/History/dto/BudgetRequestDto.java
+++ b/src/main/java/CookSave/CookSaveback/History/dto/BudgetRequestDto.java
@@ -1,0 +1,10 @@
+package CookSave.CookSaveback.History.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BudgetRequestDto {
+    private Integer budget;
+}

--- a/src/main/java/CookSave/CookSaveback/History/dto/HistoryIngredientReqDto.java
+++ b/src/main/java/CookSave/CookSaveback/History/dto/HistoryIngredientReqDto.java
@@ -1,0 +1,10 @@
+package CookSave.CookSaveback.History.dto;
+
+import lombok.Getter;
+
+@Getter
+public class HistoryIngredientReqDto {
+    private String name;
+    private Float amount;
+    private Integer price;  // 수량이 반영된 가격
+}

--- a/src/main/java/CookSave/CookSaveback/History/dto/InputHistoryReqDto.java
+++ b/src/main/java/CookSave/CookSaveback/History/dto/InputHistoryReqDto.java
@@ -1,0 +1,14 @@
+package CookSave.CookSaveback.History.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class InputHistoryReqDto {
+    private String name;  // 사용자 지정 요리명
+    private Integer total;
+    private List<HistoryIngredientReqDto> ingredients;
+}

--- a/src/main/java/CookSave/CookSaveback/History/dto/RecipeHistoryReqDto.java
+++ b/src/main/java/CookSave/CookSaveback/History/dto/RecipeHistoryReqDto.java
@@ -1,0 +1,15 @@
+package CookSave.CookSaveback.History.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class RecipeHistoryReqDto {
+    private Integer total;
+    private List<HistoryIngredientReqDto> ingredients;
+}
+
+

--- a/src/main/java/CookSave/CookSaveback/History/repository/HistoryRepository.java
+++ b/src/main/java/CookSave/CookSaveback/History/repository/HistoryRepository.java
@@ -1,0 +1,10 @@
+package CookSave.CookSaveback.History.repository;
+
+
+import CookSave.CookSaveback.History.domain.History;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HistoryRepository extends JpaRepository<History, Long> {
+}

--- a/src/main/java/CookSave/CookSaveback/History/service/HistoryService.java
+++ b/src/main/java/CookSave/CookSaveback/History/service/HistoryService.java
@@ -3,6 +3,7 @@ package CookSave.CookSaveback.History.service;
 import CookSave.CookSaveback.History.domain.History;
 import CookSave.CookSaveback.History.dto.BudgetRequestDto;
 import CookSave.CookSaveback.History.dto.HistoryIngredientReqDto;
+import CookSave.CookSaveback.History.dto.InputHistoryReqDto;
 import CookSave.CookSaveback.History.dto.RecipeHistoryReqDto;
 import CookSave.CookSaveback.History.repository.HistoryRepository;
 import CookSave.CookSaveback.HistoryIngredient.domain.HistoryIngredient;
@@ -39,6 +40,19 @@ public class HistoryService {
 
         // HistoryIngredient들 저장
         List<HistoryIngredientReqDto> historyIngredientReqDtos = recipeHistoryReqDto.getIngredients();
+        for(HistoryIngredientReqDto ingredientReqDto : historyIngredientReqDtos){
+            HistoryIngredient historyIngredient = new HistoryIngredient(history, ingredientReqDto.getName(), ingredientReqDto.getAmount(), ingredientReqDto.getPrice());
+            historyIngredientRepository.save(historyIngredient);
+        }
+    }
+
+    public void createInputHistory(Member member, InputHistoryReqDto inputHistoryReqDto) {
+        // History 저장
+        History history = new History(member, inputHistoryReqDto.getName(), inputHistoryReqDto.getTotal());
+        historyRepository.save(history);
+
+        // HistoryIngredient들 저장
+        List<HistoryIngredientReqDto> historyIngredientReqDtos = inputHistoryReqDto.getIngredients();
         for(HistoryIngredientReqDto ingredientReqDto : historyIngredientReqDtos){
             HistoryIngredient historyIngredient = new HistoryIngredient(history, ingredientReqDto.getName(), ingredientReqDto.getAmount(), ingredientReqDto.getPrice());
             historyIngredientRepository.save(historyIngredient);

--- a/src/main/java/CookSave/CookSaveback/History/service/HistoryService.java
+++ b/src/main/java/CookSave/CookSaveback/History/service/HistoryService.java
@@ -1,0 +1,18 @@
+package CookSave.CookSaveback.History.service;
+
+import CookSave.CookSaveback.History.dto.BudgetRequestDto;
+import CookSave.CookSaveback.Member.domain.Member;
+import CookSave.CookSaveback.Member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class HistoryService {
+    private final MemberRepository memberRepository;
+
+    public void updateBudget(Member member, BudgetRequestDto budgetRequestDto){
+        member.updateBudget(budgetRequestDto.getBudget());
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/CookSave/CookSaveback/History/service/HistoryService.java
+++ b/src/main/java/CookSave/CookSaveback/History/service/HistoryService.java
@@ -1,18 +1,47 @@
 package CookSave.CookSaveback.History.service;
 
+import CookSave.CookSaveback.History.domain.History;
 import CookSave.CookSaveback.History.dto.BudgetRequestDto;
+import CookSave.CookSaveback.History.dto.HistoryIngredientReqDto;
+import CookSave.CookSaveback.History.dto.RecipeHistoryReqDto;
+import CookSave.CookSaveback.History.repository.HistoryRepository;
+import CookSave.CookSaveback.HistoryIngredient.domain.HistoryIngredient;
+import CookSave.CookSaveback.HistoryIngredient.repository.HistoryIngredientRepository;
 import CookSave.CookSaveback.Member.domain.Member;
 import CookSave.CookSaveback.Member.repository.MemberRepository;
+import CookSave.CookSaveback.Recipe.domain.Recipe;
+import CookSave.CookSaveback.Recipe.repository.RecipeRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class HistoryService {
     private final MemberRepository memberRepository;
+    private final RecipeRepository recipeRepository;
+    private final HistoryRepository historyRepository;
+    private final HistoryIngredientRepository historyIngredientRepository;
 
     public void updateBudget(Member member, BudgetRequestDto budgetRequestDto){
         member.updateBudget(budgetRequestDto.getBudget());
         memberRepository.save(member);
+    }
+
+    public void createRecipeHistory(Member member, Long recipeId, RecipeHistoryReqDto recipeHistoryReqDto) {
+        // History 저장
+        Recipe recipe = recipeRepository.findById(recipeId)
+                .orElseThrow(() -> new EntityNotFoundException("recipeId " + recipeId + "인 레시피가 존재하지 않습니다."));
+        History history = new History(member, recipe.getName(), recipeHistoryReqDto.getTotal());
+        historyRepository.save(history);
+
+        // HistoryIngredient들 저장
+        List<HistoryIngredientReqDto> historyIngredientReqDtos = recipeHistoryReqDto.getIngredients();
+        for(HistoryIngredientReqDto ingredientReqDto : historyIngredientReqDtos){
+            HistoryIngredient historyIngredient = new HistoryIngredient(history, ingredientReqDto.getName(), ingredientReqDto.getAmount(), ingredientReqDto.getPrice());
+            historyIngredientRepository.save(historyIngredient);
+        }
     }
 }

--- a/src/main/java/CookSave/CookSaveback/HistoryIngredient/repository/HistoryIngredientRepository.java
+++ b/src/main/java/CookSave/CookSaveback/HistoryIngredient/repository/HistoryIngredientRepository.java
@@ -1,0 +1,9 @@
+package CookSave.CookSaveback.HistoryIngredient.repository;
+
+import CookSave.CookSaveback.HistoryIngredient.domain.HistoryIngredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HistoryIngredientRepository extends JpaRepository<HistoryIngredient, Long> {
+}

--- a/src/main/java/CookSave/CookSaveback/Member/domain/Member.java
+++ b/src/main/java/CookSave/CookSaveback/Member/domain/Member.java
@@ -26,4 +26,8 @@ public class Member {
         this.cooksaveId = cooksaveId;
         this.password = password;
     }
+
+    public void updateBudget(Integer budget){
+        this.budget = budget;
+    }
 }


### PR DESCRIPTION
# 구현 기능
- 예산 설정
- 등록되어 있는 레시피 요리 내역 저장
- 사용자가 입력한 레시피 요리 내역 저장

# 구현 상태
예산 설정
![스크린샷 2024-02-22 004856 예산 설정](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/9024e8cd-2da7-44d7-8687-4e630f91161b)
![스크린샷 2024-02-22 004415 예산 설정](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/06b62b3d-04e6-43e9-a838-52254889d864)

등록되어 있는 레시피 요리 내역 저장
![스크린샷 2024-02-22 015128 레시피 요리 내역 저장](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/b049e6b6-03f4-479c-af1d-3bc0ef0e0279)
![스크린샷 2024-02-22 015200 레시피 요리 내역 저장](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/916a1555-7761-40af-baea-e206f7c5cfe9)
![스크린샷 2024-02-22 015211 레시피 요리 내역 저장](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/6019cea9-97d4-4ed7-8795-4d715485fe02)

사용자가 입력한 레시피 요리 내역 저장
![스크린샷 2024-02-22 020649 사용자 입력 레시피 요리 내역 저장](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/5d7aaac6-043e-4061-b257-702317beb818)
![스크린샷 2024-02-22 020755 사용자 입력 레시피 요리 내역 저장](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/a7959f37-b9a8-45e6-b4b0-7bd7db0f4afb)
![스크린샷 2024-02-22 020821 사용자 입력 레시피 요리 내역 저장](https://github.com/EWHA-CAPSTONE-COOKSAVE/cooksave-back/assets/89539031/cb897985-b802-4ebb-bf39-1312ad12b9e0)